### PR TITLE
feat: Append gridBlockFee hash to ensure uniqueness

### DIFF
--- a/x/hypergridssn/keeper/msg_server_grid_block_fee.go
+++ b/x/hypergridssn/keeper/msg_server_grid_block_fee.go
@@ -5,13 +5,21 @@ import (
 
 	"hypergrid-ssn/x/hypergridssn/types"
 
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 func (k msgServer) CreateGridBlockFee(goCtx context.Context, msg *types.MsgCreateGridBlockFee) (*types.MsgCreateGridBlockFeeResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	var n = len(msg.Items)
+	if n == 0 {
+		return nil, errorsmod.Wrap(types.ErrInvalidLengthGridBlockFee, "no GridBlockFeeItem")
+	} else if n > 10000 {
+		return nil, errorsmod.Wrap(types.ErrIntOverflowGridBlockFee, "too many GridBlockFeeItem")
+	}
 
-	ids := make([]uint64, len(msg.Items))
+	ids := make([]uint64, 0, len(msg.Items))
 	for _, item := range msg.Items {
 		var gridBlockFee = types.GridBlockFee{
 			Creator:   msg.Creator,
@@ -22,7 +30,10 @@ func (k msgServer) CreateGridBlockFee(goCtx context.Context, msg *types.MsgCreat
 			Fee:       item.Fee,
 		}
 
-		//todo: make blockhash unique
+		//make blockhash unique
+		if k.HasGridBlockFeeHash(ctx, gridBlockFee.Blockhash) {
+			return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "blockhash already")
+		}
 
 		id := k.AppendGridBlockFee(
 			ctx,

--- a/x/hypergridssn/types/keys.go
+++ b/x/hypergridssn/types/keys.go
@@ -27,6 +27,7 @@ const (
 const (
 	GridBlockFeeKey      = "GridBlockFee/value/"
 	GridBlockFeeCountKey = "GridBlockFee/count/"
+	GridBlockhashKey     = "GridBlockFee/hash/"
 )
 
 const (


### PR DESCRIPTION
This commit adds functionality to append the hash of the gridBlockFee to the store, ensuring that the blockhash is unique. The `AppendGridBlockFee` function has been updated to include this logic. Additionally, a new function `HasGridBlockFeeHash` has been added to check if a key exists in the store.

Resolves: #issue_number